### PR TITLE
Fixed issue #14 caused by xib files not being assigned as resource files

### DIFF
--- a/CollapseClick.podspec
+++ b/CollapseClick.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   }
   s.homepage    = 'http://subvertapps.com'
   s.license     = 'LICENSE'
-  s.source_files = 'CollapseClick/*.{h,m,xib}'
+  s.resources = 'CollapseClick/*.{xib}'
+  s.source_files = 'CollapseClick/*.{h,m}'
   s.platform = :ios, '5.0'
   s.requires_arc = true
 end


### PR DESCRIPTION
xib files are incorrectly included as sources files which causes the error:

Unable to run command 'StripNIB CollapseClickCell.nib' - this target might include its own product.
